### PR TITLE
Port StereoSIDPlayer/SIDplay to Unix / macOS

### DIFF
--- a/Arduino/StereoSIDPlayer/SIDplay/src/main.c
+++ b/Arduino/StereoSIDPlayer/SIDplay/src/main.c
@@ -3,9 +3,23 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <fcntl.h>
-#include <windows.h>
 #include <time.h> // clock_t, clock, CLOCKS_PER_SEC
-#include <conio.h>
+
+#ifdef _WIN32
+  #include <windows.h>
+  #include <conio.h>
+#else
+  // to build on unix/macOS/linux:
+  // gcc -Wall -o sidplay main.c
+  #include <sys/types.h>
+  #include <sys/uio.h>
+  #include <unistd.h>
+  #include <stdlib.h>
+  #include <termios.h>
+  typedef int HANDLE;
+  typedef long int DWORD;
+  #define CloseHandle(h) close(h)
+#endif
 
 void delay(unsigned int milliseconds){
 
@@ -20,12 +34,16 @@ static int stereo=0;
 static int state_on=1;
 
 void serout(unsigned char *data, int len) {
-    DWORD bytes_written;
+    DWORD bytes_read;
     //printf("serout\n");
     do {
         char x;
-        ReadFile(hSerial, &x, 1, &bytes_written, NULL);
-        if (bytes_written>0) {
+#ifdef _WIN32
+        ReadFile(hSerial, &x, 1, &bytes_read, NULL);
+#else
+        bytes_read = read(hSerial, &x, 1);
+#endif
+        if (bytes_read>0) {
             if (x==0x11) {
                     state_on=1;
                     printf("o");
@@ -36,13 +54,20 @@ void serout(unsigned char *data, int len) {
             }
         }
     }
-    while (bytes_written>0 || state_on==0);
+    while (bytes_read>0 || state_on==0);
+#ifdef _WIN32
     if(!WriteFile(hSerial, data, len, &bytes_written, NULL))
+#else
+    if(write(hSerial, data, len) != len)
+#endif
     {
         fprintf(stderr, "Error\n");
         CloseHandle(hSerial);
         exit(1);
     }
+#ifndef _WIN32
+    tcdrain(hSerial); // wait for written data to finish transmitting
+#endif
 }
 
 int __ssat(int a,int b) {
@@ -181,6 +206,7 @@ void setPC(uint16_t next_pc, m6502_t *cpu, uint64_t *pins, uint8_t *mem) {
 }
 
 int open_seriak(char *name) {
+#ifdef _WIN32
     char namefull[100];
     DCB dcbSerialParams = {0};
     COMMTIMEOUTS timeouts = {0};
@@ -233,6 +259,40 @@ int open_seriak(char *name) {
         return 1;
     }
     return 0;
+#else
+    struct termios term;
+
+    fprintf(stderr, "Opening serial port...");
+    hSerial = open(name, O_RDWR | O_NOCTTY);
+    if (hSerial == -1)
+    {
+            fprintf(stderr, "Error\n");
+            return 1;
+    }
+    else fprintf(stderr, "OK\n");
+
+    if (tcgetattr(hSerial, &term) != 0)
+    {
+        fprintf(stderr, "Error getting device state\n");
+        CloseHandle(hSerial);
+        return 1;
+    }
+
+    cfmakeraw(&term);
+    cfsetspeed(&term, B115200);
+    term.c_cc[VMIN] = 0; // non-blocking read()
+    term.c_cc[VTIME] = 0; // should be zero by default, but just to be safe.
+    // timing of writes is handled by tcdrain() after write()
+
+    if(tcsetattr(hSerial, TCSANOW, &term) != 0)
+    {
+        fprintf(stderr, "Error setting device parameters\n");
+        CloseHandle(hSerial);
+        return 1;
+    }
+
+    return 0;
+#endif
 }
 
 int main(int argc, char **argv) {
@@ -240,8 +300,10 @@ int main(int argc, char **argv) {
     // 64 KB zero-initialized memory
     uint8_t mem[(1<<16)] = { };
 
+#ifdef _WIN32
     _setmode( _fileno( stdin ), _O_BINARY );
     _setmode( _fileno( stdout ), _O_BINARY );
+#endif
 
     if (argc<3) {
             printf("usage: %s COMx sound_file.sid\r\n",argv[0]);
@@ -308,9 +370,11 @@ int main(int argc, char **argv) {
             instr--;
           } while (instr%(985250/50));
 
+#ifdef _WIN32
         if (kbhit()) {
             break;
         }
+#endif
 
       }
             serout(brst,13);


### PR DESCRIPTION
Port SIDplay to work on macOS and other unix/posix systems using `termios.h` for serial communication.

Works for me on macOS 11.5.2. The Windows code paths should be unchanged behind `#ifdef _WIN32`, but I don't have a Windows GCC environment handy to test it.

----

_Original pull request message:_

_This is work in progress porting the Windows component of StereoSIDPlayer to macOS and hopefully other unix-like systems._

_It currently compiles, connects to the ARMSID, and produces sound, but it's completely garbled. Maybe a timing issue, or something not quite right about the serial port configuration._

_I haven't preserved the Windows code in this spike, but if/when the unix version works, the Windows code can be brought back in `ifdef` blocks, perhaps after a bit of refactoring/abstracting._

_Unfortunately all the line endings have changed from windows `\r\n` to unix `\n`, so you may need to [ignore whitespace changes](https://github.com/nobomi/Arduino-ARMSID-configurator/pull/2/files?w=1) to see what's really changed._

_I have no idea if/when I'll have time to work more on this, but I'll open it as a draft PR just in case it's useful._